### PR TITLE
fixed stochastic depth bug

### DIFF
--- a/nfnets_keras/nfnet_layers.py
+++ b/nfnets_keras/nfnet_layers.py
@@ -54,7 +54,7 @@ class StochasticDepth(Model):
 
     def call(self, x, training):
         if not training: return x
-        batch_size = x.shape[0]
+        batch_size = tf.shape(x)[0]
         r = tf.random.uniform(shape = [batch_size, 1, 1, 1], dtype = x.dtype)
         keep_prob = 1. - self.drop_rate
         binary_tensor = tf.floor(keep_prob + r)


### PR DESCRIPTION
Using "batch_size = x.shape[0]" will make batch_size = None which causes an error, using tf.shape(x)[0] provides the actual batch size